### PR TITLE
17436: Fix timeseries recipe test

### DIFF
--- a/tests/test_engine_timeseries.py
+++ b/tests/test_engine_timeseries.py
@@ -1,4 +1,4 @@
-tb_filename = "timeseries.ipynb"
+tb_filename = "engine_timeseries.ipynb"
 
 
 def test_r2(tb):


### PR DESCRIPTION
- Fix the test for `engine_timeseries.ipynb`