### PR TITLE
Add support for Howso dev container

### DIFF
--- a/.devcontainer/9.1.5-python3.10/devcontainer.json
+++ b/.devcontainer/9.1.5-python3.10/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "ghcr.io/howsoai/howso:9.1.5-3-python3.10",
+    "customizations": {
+        "vscode": {
+          "extensions": ["ms-toolsai.jupyter"]
+        }
+    }
+}

--- a/.devcontainer/9.1.5-python3.11/devcontainer.json
+++ b/.devcontainer/9.1.5-python3.11/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "ghcr.io/howsoai/howso:9.1.5-3-python3.11",
+    "customizations": {
+        "vscode": {
+          "extensions": ["ms-toolsai.jupyter"]
+        }
+    }
+}

--- a/.devcontainer/9.1.5-python3.8/devcontainer.json
+++ b/.devcontainer/9.1.5-python3.8/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "ghcr.io/howsoai/howso:9.1.5-3-python3.8",
+    "customizations": {
+        "vscode": {
+          "extensions": ["ms-toolsai.jupyter"]
+        }
+    }
+}

--- a/.devcontainer/9.1.5-python3.9/devcontainer.json
+++ b/.devcontainer/9.1.5-python3.9/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "ghcr.io/howsoai/howso:9.1.5-3-python3.9",
+    "customizations": {
+        "vscode": {
+          "extensions": ["ms-toolsai.jupyter"]
+        }
+    }
+}


### PR DESCRIPTION
Initial setup of the .devcontainer directory that makes it possible to use the Howso dev container to run the engine recipes.