### PR TITLE
17908: Add default devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "ghcr.io/howsoai/howso:9.1.5-3-python3.11",
+    "customizations": {
+        "vscode": {
+          "extensions": ["ms-toolsai.jupyter"]
+        }
+    }
+}


### PR DESCRIPTION
Initial attempts to use a badge in the README did not succeed. It offered to use default dev container images (i.e. jnode, etc.), but not the Howso Dev Containers. Hopefully, providing a default/Main devcontainer.json file will allow it to automatically select the dev container image specified in that file.