### PR TITLE
17944: Updated readme with dev container info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,64 @@
 # Howso Engine&trade; Recipes
 
 This repository contains a collection of common use-cases primarily in Jupyter
-Notebook form. This is to help demonstrate not only the capabilities of
-[Howso Engine](https://github.com/howsoai/howso-engine) but to also illustrate important concepts and show how these
-tools can be used.
+Notebook form. They help demonstrate not only the capabilities of
+[Howso Engine](https://github.com/howsoai/howso-engine) but also 
+important concepts and usage instructions.
 
+There are two main methods for setting up to run the recipes:
+- Use a prebuilt VS Code dev container (requires VS Code and Docker)
+  - VS Code and Docker are required, but a python environment isn't 
+  - Run notebooks in VS Code only
+- Install Howso Engine locally
+  - Howso Engine and dependencies are installed into your local python environment
+  - Run notebooks using whatever application you prefer (e.g. Jupyter servers, IDEs)
 
-## Installation
+## Run in a Dev Container
+Running in a dev container is a quick method to get set up to run the recipes,
+assuming that you'd like to use Docker and VS Code. You can use the dev containers
+either by cloning this repo first and reopening VS Code, or using the "one click"
+method that does both steps for you.
 
-This repository is not a package to be installed in the usual sense, but rather
-placed onto the local filesystem where the various notebooks can be
-interactively run, modified and explored.
+### Reopen in a Dev Container
+There are a few quick steps needed to use the reopen method:
+1. Clone this repository and cd into `howso-engine-recipes`
+1. Start VS Code from the cloned repo directory using `code .`
+1. Use the blue "><" button in the lower left corner of VS Code to open the dev container menu.
+1. Select "Reopen in Container" and pick which dev container version you'd like to to use for the current session
+1. Once it's restarted, you should be able to run recipes/notebooks and python from that VS Code session using Howso Engine
 
-    cd your_local_workspace
-    unzip howso-recipes-engine-[VERSION].zip
-    cd howso-recipes-engine-[VERSION]
+### One Click Clone and Run in a Dev Container
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/howsoai/howso-engine-recipes)
 
+If you already have VS Code and Docker installed, you can click the badge above
+or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/howsoai/howso-engine-recipes) 
+to get started without cloning first and reopening VS Code. Clicking these links
+will cause VS Code to automatically install the Dev Containers extension if
+needed, clone the recipes into a container volume, and spin up a dev container
+for use.
+
+Note that this method clones the recipes into a docker volume, which essentially
+means that the setup is cached. If you'd like to use this method again later with
+a newer version of the recipes and engine, you'll need to clear the cached volume.
+Do that by using `docker volume list` to find the
+`howso-engine-recipes-<hash>` volume, then use 
+`docker volume rm howso-engine-recipes-<hash>` to remove the volume so VS Code
+ will re-clone the repo and insure that you're using both the latest recipes and
+ latest Howso Dev Container (including the most recent release of Howso
+ Engine).
+
+## Local Installation
+
+This repository is not a package to be installed in the usual sense. It's a
+collection of Jupyter notebooks that can be be cloned into your local filesystem
+and interactively run, modified and explored. To do that, the python package
+dependencies, including Howso Engine, must be installed. Start by cloning this
+repo and opening a terminal in the resulting directory.
 
 ### Virtual Python Environment
 
 Howso strongly recommends isolating from other Python projects with a
-virtual enviroment. How this is done depends on your work-flow.
+virtual environment. How this is done depends on your work-flow.
 
 For example, if you use `venv`:
 
@@ -40,19 +78,9 @@ activate the venv and install requirements with:
 
     pip install -r requirements.in
 
-Among other things, this will install Jupyter notebook support. To get started,
-run in your terminal:
-
-    jupyter lab
-
-This should open a new window/tab in your browser, but if not, follow the
-instructions emitted to your terminal by the Jupyter notebook server and either
-CTRL-click one of the URLs, or simply copy and paste the URL into your browser.
-
-From here, you should have available to you all of the Howso recipes for
-Engine as Jupyter notebooks. If you're un-familiar with using JupyterLab or
-Notebooks, please visit: [jupyter.org](https://jupyter.org/) and
-[Jupyter's documentation](https://docs.jupyter.org/en/latest/) to learn more.
+If successful, Howso Engine and all dependencies needed to run the recipes are
+installed. It should be possible to run any of the recipes using your preferred
+method of running Jupyter notebooks (e.g. Jupyter server, VS Code, etc.)
 
 Happy exploring!
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@ important concepts and usage instructions.
 
 There are two main methods for setting up to run the recipes:
 - Use a prebuilt VS Code dev container (requires VS Code and Docker)
-  - VS Code and Docker are required, but a python environment isn't 
+  - Quicker startup method to try out Howso Engine or if dev containers are already part of your work environment
+  - VS Code and Docker are required, but a Python environment isn't 
   - Run notebooks in VS Code only
 - Install Howso Engine locally
-  - Howso Engine and dependencies are installed into your local python environment
+  - Typical setup for those familiar with Python development
+  - Howso Engine and dependencies are installed into your local Python environment
   - Run notebooks using whatever application you prefer (e.g. Jupyter servers, IDEs)
 
 ## Run in a Dev Container
 Running in a dev container is a quick method to get set up to run the recipes,
-assuming that you'd like to use Docker and VS Code. You can use the dev containers
+assuming that you'd like to use Docker and VS Code. This method uses 
+[container images](https://github.com/howsoai/howso-devcontainers/pkgs/container/howso)
+built as part of the [Howso Developement Containers](https://github.com/howsoai/howso-devcontainers).
+You can use the dev containers
 either by cloning this repo first and reopening VS Code, or using the "one click"
 method that does both steps for you.
 
@@ -25,7 +30,7 @@ There are a few quick steps needed to use the reopen method:
 1. Start VS Code from the cloned repo directory using `code .`
 1. Use the blue "><" button in the lower left corner of VS Code to open the dev container menu.
 1. Select "Reopen in Container" and pick which dev container version you'd like to to use for the current session
-1. Once it's restarted, you should be able to run recipes/notebooks and python from that VS Code session using Howso Engine
+1. Once it's restarted, you should be able to run recipes/notebooks and Python from that VS Code session using Howso Engine
 
 ### One Click Clone and Run in a Dev Container
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/howsoai/howso-engine-recipes)
@@ -37,13 +42,13 @@ will cause VS Code to automatically install the Dev Containers extension if
 needed, clone the recipes into a container volume, and spin up a dev container
 for use.
 
-Note that this method clones the recipes into a docker volume, which essentially
+Note that this method clones the recipes into a Docker volume, which essentially
 means that the setup is cached. If you'd like to use this method again later with
 a newer version of the recipes and engine, you'll need to clear the cached volume.
 Do that by using `docker volume list` to find the
 `howso-engine-recipes-<hash>` volume, then use 
 `docker volume rm howso-engine-recipes-<hash>` to remove the volume so VS Code
- will re-clone the repo and insure that you're using both the latest recipes and
+ will re-clone the repo and ensure that you're using both the latest recipes and
  latest Howso Dev Container (including the most recent release of Howso
  Engine).
 
@@ -51,7 +56,7 @@ Do that by using `docker volume list` to find the
 
 This repository is not a package to be installed in the usual sense. It's a
 collection of Jupyter notebooks that can be be cloned into your local filesystem
-and interactively run, modified and explored. To do that, the python package
+and interactively run, modified and explored. To do that, the Python package
 dependencies, including Howso Engine, must be installed. Start by cloning this
 repo and opening a terminal in the resulting directory.
 


### PR DESCRIPTION
Added information about how to use the Howso Development Container to run recipes, plus a little cleanup.