### PR TITLE
17481: Adjusts number of pytest workers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -77,4 +77,4 @@ jobs:
             pip install amlg/*.whl
           fi
           loglevel=${1:-INFO}
-          python -m pytest -n 4 -s --log-cli-level=${loglevel} -o junit_family=xunit2 --junitxml=junit/test-results.xml
+          python -m pytest -s --log-cli-level=${loglevel} -o junit_family=xunit2 --junitxml=junit/test-results.xml


### PR DESCRIPTION
I had tried adjusting the number of pytest workers to 4 to speed up the jobs, but multithreaded Amalgam (or the testing framework we're using) does not like that very much. This will reduce the number of workers back to 1 until some more testing can be completed.