### PR TITLE
19729: Adjusts name of MacOS Pytest job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
 
-  pytest-macos-3-12-mt-amd64:
+  pytest-macos-3-11-mt-amd64:
     if: inputs.build-type != 'PR'
     needs: ['metadata']
     uses: howsoai/.github/.github/workflows/pytest.yml@main
@@ -133,7 +133,7 @@ jobs:
       platform: 'macos-latest'
       platform-pretty: 'MacOS'
       amalgam-plat-arch: 'darwin-amd64'
-      python-version: '3.12'
+      python-version: '3.11'
       config-fp: './config/latest-mt-noavx-debug-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
@@ -160,7 +160,7 @@ jobs:
       - pytest-linux-3-11-st
       - pytest-linux-3-12-mt
       - pytest-windows-3-12-mt
-      - pytest-macos-3-12-mt-amd64
+      - pytest-macos-3-11-mt-amd64
       - pytest-macos-3-12-mt-arm64
     if: inputs.build-type == 'release'
     permissions:


### PR DESCRIPTION
This is necessary to avoid a conflict in the tracefile artifact upload process, reverting a bug in #96 .