### PR TITLE
17481: Updates MacOS Pytest job to specify x86 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
     uses: howsoai/.github/.github/workflows/pytest.yml@main
     secrets: inherit
     with:
-      platform: 'macos-latest'
+      platform: 'macos-13' # macos-latest now points to arm64 runners
       platform-pretty: 'MacOS'
       amalgam-plat-arch: 'darwin-amd64'
       python-version: '3.11'


### PR DESCRIPTION
GitHub has updated its `macos-latest` runner to use ARM architecture. This ensures that we can still test on an x86 architecture.