### PR TITLE
17481: Update tests to use absolute filepath for Howso config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       platform-pretty: 'Linux'
       amalgam-plat-arch: 'linux-amd64'
       python-version: '3.9'
-      config-fp: './config/latest-st-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-st-debug-howso.yml'
       config-pretty: 'ST'
       workers: 'auto'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
@@ -76,7 +76,7 @@ jobs:
       platform-pretty: 'Linux'
       amalgam-plat-arch: 'linux-amd64'
       python-version: '3.10'
-      config-fp: './config/latest-st-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-st-debug-howso.yml'
       config-pretty: 'ST'
       workers: 'auto'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
@@ -91,7 +91,7 @@ jobs:
       platform-pretty: 'Linux'
       amalgam-plat-arch: 'linux-amd64'
       python-version: '3.11'
-      config-fp: './config/latest-st-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-st-debug-howso.yml'
       config-pretty: 'ST'
       workers: 'auto'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
@@ -106,7 +106,7 @@ jobs:
       platform-pretty: 'Linux'
       amalgam-plat-arch: 'linux-amd64'
       python-version: '3.12'
-      config-fp: './config/latest-mt-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-mt-debug-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
 
@@ -120,7 +120,7 @@ jobs:
       platform-pretty: 'Windows'
       amalgam-plat-arch: 'windows-amd64'
       python-version: '3.12'
-      config-fp: './config/latest-mt-debug-howso.yml'
+      config-fp: '/d/a/howso-engine-recipes/howso-engine-recipes/config/latest-mt-debug-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
 
@@ -134,7 +134,7 @@ jobs:
       platform-pretty: 'MacOS'
       amalgam-plat-arch: 'darwin-amd64'
       python-version: '3.11'
-      config-fp: './config/latest-mt-noavx-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-mt-noavx-debug-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
 
@@ -148,7 +148,7 @@ jobs:
       platform-pretty: 'MacOS'
       amalgam-plat-arch: 'darwin-arm64'
       python-version: '3.12'
-      config-fp: './config/latest-mt-debug-howso.yml'
+      config-fp: '~/work/howso-engine-recipes/howso-engine-recipes/config/latest-mt-debug-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
 


### PR DESCRIPTION
This is necessary due to #91 .