### PR TITLE
21137: Fixes matplotlib 3.9.1 issue on Windows

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ ipyreact
 jupyter-core>=4.7.0
 kaleido; sys_platform != "win32"
 kaleido==0.1.0.post1; sys_platform == "win32"
-matplotlib~=3.4
+matplotlib~=3.0, !=3.9.1
 notebook>6.0.0
 numpy
 pandas[parquet]~=2.0


### PR DESCRIPTION
Fixes [this issue](https://github.com/matplotlib/matplotlib/issues/28551) in `matplotlib` 3.9.1.