### PR TITLE
23883: Updates HOWSO_CONFIG absolute path for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       platform-pretty: 'Windows'
       amalgam-plat-arch: 'windows-amd64'
       python-version: '3.12'
-      config-fp: '/d/a/howso-engine-recipes/howso-engine-recipes/config/latest-mt-traces-howso.yml'
+      config-fp: '/c/a/howso-engine-recipes/howso-engine-recipes/config/latest-mt-traces-howso.yml'
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
       debug: ${{ inputs.debug-mode }}


### PR DESCRIPTION
The filesystem structure has recently changed in the GitHub Windows runner, and since the config path must be absolute here, it needs updating.