### PR TITLE
24070: Removes scheduled recipe re-runs

### DIFF
--- a/.github/workflows/recipes-rerun.yml
+++ b/.github/workflows/recipes-rerun.yml
@@ -21,8 +21,6 @@ on:
         required: true
         type: boolean
         default: false
-  schedule:
-    - cron: '0 12 */14 * 2'
 
 defaults:
   run:


### PR DESCRIPTION
Often times, these automated re-runs did not line up with when we wanted to actually re-run them.