### PR TITLE
24276: Updates recipes to not use `features` parameter to IFA

### DIFF
--- a/recipes/4-Examples/extra_examples/car_type_demo.ipynb
+++ b/recipes/4-Examples/extra_examples/car_type_demo.ipynb
@@ -671,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "35704d73",
    "metadata": {
     "execution": {
@@ -866,12 +866,11 @@
     "custom_features = {}\n",
     "\n",
     "cont_features = ['CityMPG', 'HighwayMPG', 'PassengerVolume', 'LuggageVolume', 'Year']\n",
-    "for ft in cont_features:\n",
-    "    custom_features[ft] = {'type': 'continuous'}\n",
+    "types = {'continuous': cont_features}\n",
     "\n",
     "# Infer feature attributes, with a dictionary where types for continuous feature\n",
     "# are pre-defined\n",
-    "features = infer_feature_attributes(df, features=custom_features)\n",
+    "features = infer_feature_attributes(df, types=types)\n",
     "\n",
     "features.to_dataframe()"
    ]

--- a/recipes/4-Examples/extra_examples/predict_explain_show.ipynb
+++ b/recipes/4-Examples/extra_examples/predict_explain_show.ipynb
@@ -392,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6f16acd5-4006-4488-a71a-1be4692d6479",
    "metadata": {
     "execution": {
@@ -404,12 +404,12 @@
    },
    "outputs": [],
    "source": [
-    "partial_features = {\n",
-    "    \"education\": {\"type\": \"nominal\"}\n",
+    "types = {\n",
+    "    \"education\": \"nominal\"\n",
     "}\n",
     "\n",
     "# Infer features attributes\n",
-    "features = infer_feature_attributes(df, features=partial_features)\n",
+    "features = infer_feature_attributes(df, types=types)\n",
     "\n",
     "# Specify the context and action feature\n",
     "action_features = ['target']\n",


### PR DESCRIPTION
Follow-up to https://github.com/howsoai/howso-engine-py/pull/478