### PR TITLE
00000: Resolve JavaScript Dependabot alerts, PATCH

### DIFF
--- a/widgets/package-lock.json
+++ b/widgets/package-lock.json
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1027,9 +1027,9 @@
       "peer": true
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -1118,9 +1118,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -1201,15 +1201,17 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8.6"
@@ -1237,9 +1239,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.45",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1254,11 +1256,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1949,15 +1952,19 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
       "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Resolves all 13 currently open JavaScript/npm Dependabot alerts reported against `widgets/package-lock.json`.
- Keeps `widgets/package.json` unchanged and updates only the npm v3 lockfile.
- Bumps the vulnerable transitive packages to patched versions: `brace-expansion` 2.1.4, `lodash` 4.18.1, `picomatch` 2.3.2, `postcss` 8.5.25, and `yaml` 2.9.0.
- Also refreshes `postcss` transitive metadata for `nanoid` 3.3.17 and `picocolors` 1.1.1 as required by the updated `postcss` package metadata.

## Dependabot alerts addressed

High severity:
- #425: npm/brace-expansion in `widgets/package-lock.json` — GHSA-mh99-v99m-4gvg / CVE-2026-14257; vulnerable `>= 2.0.0, < 2.1.3`; fixed by 2.1.4.
- #426: npm/brace-expansion in `widgets/package-lock.json` — GHSA-3jxr-9vmj-r5cp / CVE-2026-13149; vulnerable `>= 2.0.0, < 2.1.2`; fixed by 2.1.4.
- #427: npm/brace-expansion in `widgets/package-lock.json` — GHSA-rgw5-rvv9-x895 / CVE-2026-69152; vulnerable `>= 2.0.0, < 2.1.4`; fixed by 2.1.4.
- #260: npm/lodash in `widgets/package-lock.json` — GHSA-r5fr-rjxr-66jc / CVE-2026-4800; vulnerable `>= 4.0.0, <= 4.17.23`; fixed by 4.18.1.
- #249: npm/picomatch in `widgets/package-lock.json` — GHSA-c2c7-rcm5-vvqj / CVE-2026-33671; vulnerable `< 2.3.2`; fixed by 2.3.2.
- #422: npm/postcss in `widgets/package-lock.json` — GHSA-6g55-p6wh-862q / CVE-2026-45623; vulnerable `<= 8.5.11`; fixed by 8.5.25.
- #424: npm/postcss in `widgets/package-lock.json` — GHSA-r28c-9q8g-f849; vulnerable `<= 8.5.17`; fixed by 8.5.25.

Medium severity:
- #248: npm/brace-expansion in `widgets/package-lock.json` — GHSA-f886-m6hf-6m8v / CVE-2026-33750; vulnerable `>= 2.0.0, < 2.0.3`; fixed by 2.1.4.
- #259: npm/lodash in `widgets/package-lock.json` — GHSA-f23m-r3pf-42rh / CVE-2026-2950; vulnerable `<= 4.17.23`; fixed by 4.18.1.
- #250: npm/picomatch in `widgets/package-lock.json` — GHSA-3v7f-55p6-f55p / CVE-2026-33672; vulnerable `< 2.3.2`; fixed by 2.3.2.
- #261: npm/postcss in `widgets/package-lock.json` — GHSA-qx2v-qp2m-jg93 / CVE-2026-41305; vulnerable `< 8.5.10`; fixed by 8.5.25.
- #428: npm/postcss in `widgets/package-lock.json` — GHSA-fxqj-rqcc-2cmp / CVE-2026-69153; vulnerable `<= 8.5.22`; fixed by 8.5.25.
- #247: npm/yaml in `widgets/package-lock.json` — GHSA-48c2-rrv3-qjmp / CVE-2026-33532; vulnerable `>= 2.0.0, < 2.8.3`; fixed by 2.9.0.

## Verification
- `npm update brace-expansion lodash picomatch postcss yaml --package-lock-only --ignore-scripts` — completed; `found 0 vulnerabilities`.
- `npm audit --package-lock-only --omit=dev` — passed; `found 0 vulnerabilities`.
- Dependency-floor validation script — passed for `brace-expansion >=2.1.4`, `lodash >=4.18.0`, `picomatch >=2.3.2`, `postcss >=8.5.23`, and `yaml >=2.8.3`.
- `git diff --check` — passed.
- Independent Claude Code review of the diff — no blocking findings; confirmed the diff is minimal, lockfile v3-consistent, and likely to close the alerts.

## Blocked / not fully verified locally
- `npm ci --ignore-scripts` could not complete in this worker because the private `@howso` JFrog npm registry returned `E401 Incorrect or missing password` while fetching the checked-in private `@howso` package. No secrets were exposed.

## Residual risk / next action
- A human must approve and merge this PR.
- After merge, GitHub Dependabot should rescan `widgets/package-lock.json` and close the 13 alerts listed above.
